### PR TITLE
Rename app to jangolo across platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# firstapp
+# jangolo
 
 A new Flutter project.
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.firstapp"
+    namespace = "com.example.jangolo"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = "27.0.12077973"
 
@@ -23,7 +23,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.example.firstapp"
+        applicationId = "com.example.jangolo"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -9,7 +9,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:370850548318:android:96d8e459685c55cc2482cf",
         "android_client_info": {
-          "package_name": "com.example.firstapp"
+          "package_name": "com.example.jangolo"
         }
       },
       "oauth_client": [],

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="firstapp"
+        android:label="jangolo"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/kotlin/com/example/jangolo/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/jangolo/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.firstapp
+package com.example.jangolo
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.jangolo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.jangolo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.jangolo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.jangolo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.jangolo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.jangolo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -4,8 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleDisplayName</key>
-	<string>Firstapp</string>
+        <key>CFBundleDisplayName</key>
+        <string>jangolo</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>firstapp</string>
+	<string>jangolo</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/core/navigation/main_nav_shell.dart
+++ b/lib/core/navigation/main_nav_shell.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:firstapp/src/screens/search_screen.dart';
-import 'package:firstapp/src/screens/home_shell.dart';
-import 'package:firstapp/src/screens/stock_screen.dart';
-import 'package:firstapp/src/screens/notifications_screen.dart';
+import 'package:jangolo/src/screens/search_screen.dart';
+import 'package:jangolo/src/screens/home_shell.dart';
+import 'package:jangolo/src/screens/stock_screen.dart';
+import 'package:jangolo/src/screens/notifications_screen.dart';
 // ➜ L'IMPORT A ÉTÉ MIS À JOUR ICI
-import 'package:firstapp/features/purchases/presentation/screens/purchases_list_screen.dart';
+import 'package:jangolo/features/purchases/presentation/screens/purchases_list_screen.dart';
 
 class MainNavShell extends StatefulWidget {
   const MainNavShell({super.key});

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -64,7 +64,7 @@ class DefaultFirebaseOptions {
     messagingSenderId: '370850548318',
     projectId: 'jangolo-89938',
     storageBucket: 'jangolo-89938.firebasestorage.app',
-    iosBundleId: 'com.example.firstapp',
+    iosBundleId: 'com.example.jangolo',
   );
 
   static const FirebaseOptions macos = FirebaseOptions(
@@ -73,7 +73,7 @@ class DefaultFirebaseOptions {
     messagingSenderId: '370850548318',
     projectId: 'jangolo-89938',
     storageBucket: 'jangolo-89938.firebasestorage.app',
-    iosBundleId: 'com.example.firstapp',
+    iosBundleId: 'com.example.jangolo',
   );
 
   static const FirebaseOptions windows = FirebaseOptions(

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "firstapp")
+set(BINARY_NAME "jangolo")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.firstapp")
+set(APPLICATION_ID "com.example.jangolo")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -40,11 +40,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "firstapp");
+    gtk_header_bar_set_title(header_bar, "jangolo");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "firstapp");
+    gtk_window_set_title(window, "jangolo");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* firstapp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "firstapp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* jangolo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "jangolo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* firstapp.app */,
+				33CC10ED2044A3C60003C045 /* jangolo.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -217,7 +217,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* firstapp.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* jangolo.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -385,10 +385,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.jangolo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/firstapp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/firstapp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/jangolo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/jangolo";
 			};
 			name = Debug;
 		};
@@ -399,10 +399,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.jangolo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/firstapp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/firstapp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/jangolo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/jangolo";
 			};
 			name = Release;
 		};
@@ -413,10 +413,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.firstapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.jangolo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/firstapp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/firstapp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/jangolo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/jangolo";
 			};
 			name = Profile;
 		};

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "firstapp.app"
+               BuildableName = "jangolo.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "firstapp.app"
+            BuildableName = "jangolo.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "firstapp.app"
+            BuildableName = "jangolo.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "firstapp.app"
+            BuildableName = "jangolo.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,10 +5,10 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = firstapp
+PRODUCT_NAME = jangolo
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.firstapp
+PRODUCT_BUNDLE_IDENTIFIER = com.example.jangolo
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: firstapp
+name: jangolo
 description: "A new Flutter project."
 publish_to: 'none' 
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:firstapp/main.dart'; // Assure-toi que le nom du package = nom du dossier (firstapp)
+import 'package:jangolo/main.dart'; // Assure-toi que le nom du package = nom du dossier (jangolo)
 
 void main() {
   testWidgets('Le compteur s’incrémente de 0 à 1', (WidgetTester tester) async {

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="firstapp">
+  <meta name="apple-mobile-web-app-title" content="jangolo">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>firstapp</title>
+  <title>jangolo</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "firstapp",
-    "short_name": "firstapp",
+    "name": "jangolo",
+    "short_name": "jangolo",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(firstapp LANGUAGES CXX)
+project(jangolo LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "firstapp")
+set(BINARY_NAME "jangolo")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "firstapp" "\0"
+            VALUE "FileDescription", "jangolo" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "firstapp" "\0"
+            VALUE "InternalName", "jangolo" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "firstapp.exe" "\0"
-            VALUE "ProductName", "firstapp" "\0"
+            VALUE "OriginalFilename", "jangolo.exe" "\0"
+            VALUE "ProductName", "jangolo" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"firstapp", origin, size)) {
+  if (!window.Create(L"jangolo", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
- rename Flutter project to `jangolo` in pubspec and imports
- update Android, iOS, macOS, web, Linux, and Windows configs from `firstapp` to `jangolo`
- adjust Firebase and package references to new bundle identifier

## Testing
- ❌ `flutter pub get` (command not found)
- ❌ `flutter build apk` (command not found)
- ❌ `flutter build ios` (command not found)
- ❌ `flutter build macos` (command not found)
- ❌ `flutter build web` (command not found)
- ❌ `flutter build linux` (command not found)
- ❌ `flutter build windows` (command not found)
- ❌ `flutter test` (command not found)
- ⚠️ `apt-get update` (repository 403)


------
https://chatgpt.com/codex/tasks/task_e_68b98cb69950832db551444c68eb9338