### PR TITLE
Improve purchase creation form validation and payment logic

### DIFF
--- a/lib/features/purchases/presentation/screens/create_purchase_screen.dart
+++ b/lib/features/purchases/presentation/screens/create_purchase_screen.dart
@@ -65,6 +65,9 @@ class _CreatePurchaseScreenState extends State<CreatePurchaseScreen> {
 
   final String _currency = 'F';
   bool _isSaving = false;
+
+  // Contrôleur persistant pour la recherche dans les sélecteurs
+  final TextEditingController _pickerSearchCtrl = TextEditingController();
   
   // --- Instances pour la logique métier ---
   late final CreatePurchase _createPurchase;
@@ -139,6 +142,7 @@ class _CreatePurchaseScreenState extends State<CreatePurchaseScreen> {
   @override
   void dispose() {
     _pageController.dispose();
+    _pickerSearchCtrl.dispose();
     super.dispose();
   }
   
@@ -729,7 +733,7 @@ void _showStyledPicker({
   required ValueChanged<String> onSelected,
   Widget? actionButton,
 }) {
-  final searchController = TextEditingController();
+  _pickerSearchCtrl.clear();
   showModalBottomSheet(
     context: context,
     useSafeArea: true,
@@ -745,7 +749,7 @@ void _showStyledPicker({
           final filteredItems = items
               .where((item) => item
                   .toLowerCase()
-                  .contains(searchController.text.toLowerCase()))
+                  .contains(_pickerSearchCtrl.text.toLowerCase()))
               .toList();
           final theme = Theme.of(context);
 
@@ -767,7 +771,7 @@ void _showStyledPicker({
                   ),
                   const SizedBox(height: 16),
                   TextField(
-                    controller: searchController,
+                    controller: _pickerSearchCtrl,
                     onChanged: (_) => setState(() {}),
                     decoration: InputDecoration(
                       hintText: 'Rechercher...',
@@ -814,5 +818,5 @@ void _showStyledPicker({
         },
       );
     },
-  ).whenComplete(() => searchController.dispose());
+  );
 }

--- a/lib/features/purchases/presentation/widgets/create_purchase/form_widgets.dart
+++ b/lib/features/purchases/presentation/widgets/create_purchase/form_widgets.dart
@@ -121,7 +121,14 @@ class PickerFormField extends StatelessWidget {
     return FormField<String>(
       validator: validator,
       builder: (state) {
-        if (state.value != value) state.didChange(value);
+        // ✅ --- CORRECTION APPLIQUÉE ICI ---
+        // On vérifie si la valeur a changé et on programme la mise à jour
+        // pour qu'elle s'exécute juste après la fin du processus de build.
+        if (state.value != value) {
+          Future.microtask(() => state.didChange(value));
+        }
+        // --- FIN DE LA CORRECTION ---
+
         return InkWell(
           onTap: onTap,
           borderRadius: BorderRadius.circular(12),

--- a/lib/features/purchases/presentation/widgets/create_purchase/form_widgets.dart
+++ b/lib/features/purchases/presentation/widgets/create_purchase/form_widgets.dart
@@ -99,6 +99,55 @@ class PickerField extends StatelessWidget {
   }
 }
 
+// Version FormField avec validation pour les PickerField
+class PickerFormField extends StatelessWidget {
+  final String label;
+  final String? value;
+  final VoidCallback onTap;
+  final IconData? prefixIcon;
+  final String? Function(String?)? validator;
+
+  const PickerFormField({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.onTap,
+    this.prefixIcon,
+    this.validator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FormField<String>(
+      validator: validator,
+      builder: (state) {
+        if (state.value != value) state.didChange(value);
+        return InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: InputDecorator(
+            decoration: _m3InputDecoration(
+                  context,
+                  label: label,
+                  prefixIcon: prefixIcon,
+                ).copyWith(errorText: state.errorText),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: Text(
+                value ?? 'Sélectionner...',
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyLarge
+                    ?.copyWith(fontWeight: FontWeight.w500),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
 class LineTile extends StatelessWidget {
   final LineItem item;
   final String currency;

--- a/lib/features/purchases/presentation/widgets/create_purchase/payment_and_reception_step.dart
+++ b/lib/features/purchases/presentation/widgets/create_purchase/payment_and_reception_step.dart
@@ -130,10 +130,11 @@ class PaymentAndReceptionStep extends StatelessWidget {
             _TotalRow(label: 'Total Payé', value: _money(totalPaid)),
             const Divider(height: 20),
             _TotalRow(
-              label: 'Solde Restant',
-              value: _money(balanceDue),
+              label: balanceDue >= 0 ? 'Solde Restant' : 'Crédit',
+              value: _money(balanceDue.abs()),
               isBold: true,
-              color: balanceDue > 0 ? theme.colorScheme.error : Colors.green,
+              color:
+                  balanceDue > 0 ? theme.colorScheme.error : Colors.green,
             ),
           ],
         ),

--- a/lib/features/purchases/presentation/widgets/create_purchase/supplier_info_form.dart
+++ b/lib/features/purchases/presentation/widgets/create_purchase/supplier_info_form.dart
@@ -30,23 +30,25 @@ class SupplierInfoForm extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Champ Fournisseur (maintenant un PickerField)
-        PickerField(
+        // Champ Fournisseur (FormField pour validation)
+        PickerFormField(
           key: const Key('supplier-field'),
           label: 'Fournisseur *',
-          value: supplier ?? 'Sélectionner...',
+          value: supplier,
           onTap: onSupplierTap,
           prefixIcon: Icons.store_mall_directory_outlined,
+          validator: (v) => v == null ? 'Requis' : null,
         ),
         const SizedBox(height: _vGap),
 
         // Champ Entrepôt
-        PickerField(
+        PickerFormField(
           key: const Key('warehouse-field'),
           label: 'Entrepôt de destination *',
-          value: warehouse ?? 'Sélectionner...',
+          value: warehouse,
           onTap: onWarehouseTap,
           prefixIcon: Icons.home_work_outlined,
+          validator: (v) => v == null ? 'Requis' : null,
         ),
         const SizedBox(height: _vGap),
         


### PR DESCRIPTION
## Summary
- validate supplier and warehouse fields and block navigation until filled
- add payment amount checks and dispose controllers to avoid leaks
- replace transient keys with stable IDs and confirm item deletions
- persist picker search text and handle overpayments as credits

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5e6f82e8832dac8b987d0fd18b92