### PR TITLE
feat: implement purchase details view

### DIFF
--- a/lib/features/purchases/data/datasources/remote_datasource.dart
+++ b/lib/features/purchases/data/datasources/remote_datasource.dart
@@ -36,7 +36,7 @@ class PurchaseRemoteDataSourceImpl implements PurchaseRemoteDataSource {
             .toList();
       });
     } catch (e) {
-      print('Erreur lors de la récupération des achats: $e');
+      // ✅ CORRECTION: Le print a été retiré. Dans une vraie app, on utiliserait un logger.
       throw Exception('Impossible de charger les achats.');
     }
   }
@@ -69,7 +69,7 @@ class PurchaseRemoteDataSourceImpl implements PurchaseRemoteDataSource {
       await batch.commit();
       
     } catch (e) {
-      print('Erreur lors de la création de l\'achat: $e');
+      // ✅ CORRECTION: Le print a été retiré.
       throw Exception('Impossible de sauvegarder l\'achat.');
     }
   }
@@ -86,7 +86,8 @@ class PurchaseRemoteDataSourceImpl implements PurchaseRemoteDataSource {
     final purchaseDoc = await purchaseRef.get();
 
     if (!purchaseDoc.exists) {
-      return (null, []);
+      // ✅ CORRECTION: On spécifie le type de la liste vide pour corriger l'erreur.
+      return (null, <PurchaseLineModel>[]);
     }
 
     final itemsSnapshot = await purchaseRef.collection('items').get();

--- a/lib/features/purchases/data/repositories/purchase_repository_impl.dart
+++ b/lib/features/purchases/data/repositories/purchase_repository_impl.dart
@@ -42,9 +42,30 @@ class PurchaseRepositoryImpl implements PurchaseRepository {
   Future<PurchaseEntity?> getPurchaseDetails({
     required String organizationId,
     required String purchaseId,
-  }) {
-    // TODO: Implémenter la logique pour récupérer les détails
-    throw UnimplementedError();
+  }) async {
+    final (purchaseModel, itemModels) =
+        await remoteDataSource.getPurchaseDetails(organizationId, purchaseId);
+
+    if (purchaseModel == null) {
+      return null;
+    }
+
+    return PurchaseEntity(
+      id: purchaseModel.id,
+      supplier: purchaseModel.supplier,
+      status: purchaseModel.status,
+      createdAt: purchaseModel.createdAt,
+      eta: purchaseModel.eta,
+      warehouse: purchaseModel.warehouse,
+      items: itemModels,
+      payments: purchaseModel.payments,
+      reference: purchaseModel.reference,
+      paymentTerms: purchaseModel.paymentTerms,
+      notes: purchaseModel.notes,
+      globalDiscount: purchaseModel.globalDiscount,
+      shippingFees: purchaseModel.shippingFees,
+      otherFees: purchaseModel.otherFees,
+    );
   }
 
   @override

--- a/lib/features/purchases/presentation/screens/purchase_detail_screen.dart
+++ b/lib/features/purchases/presentation/screens/purchase_detail_screen.dart
@@ -1,0 +1,225 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../data/datasources/remote_datasource.dart';
+import '../../data/repositories/purchase_repository_impl.dart';
+import '../../domain/entities/purchase_entity.dart';
+import '../../domain/entities/purchase_line_entity.dart';
+import '../../domain/usecases/get_purchase_details.dart';
+
+class PurchaseDetailScreen extends StatefulWidget {
+  final String purchaseId;
+  const PurchaseDetailScreen({super.key, required this.purchaseId});
+
+  @override
+  State<PurchaseDetailScreen> createState() => _PurchaseDetailScreenState();
+}
+
+class _PurchaseDetailScreenState extends State<PurchaseDetailScreen> {
+  late final GetPurchaseDetails _getPurchaseDetails;
+  Future<PurchaseEntity?>? _purchaseFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    final remoteDataSource =
+        PurchaseRemoteDataSourceImpl(firestore: FirebaseFirestore.instance);
+    final repository =
+        PurchaseRepositoryImpl(remoteDataSource: remoteDataSource);
+    _getPurchaseDetails = GetPurchaseDetails(repository);
+    _purchaseFuture = _loadPurchase();
+  }
+
+  Future<PurchaseEntity?> _loadPurchase() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return null;
+    final userDoc = await FirebaseFirestore.instance
+        .collection('utilisateurs')
+        .doc(user.uid)
+        .get();
+    final orgId = userDoc.data()?['organizationId'] as String?;
+    if (orgId == null) return null;
+    return _getPurchaseDetails(
+        organizationId: orgId, purchaseId: widget.purchaseId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Détail de l'achat"),
+      ),
+      body: FutureBuilder<PurchaseEntity?>(
+        future: _purchaseFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError || !snapshot.hasData || snapshot.data == null) {
+            return const Center(
+                child: Text("Impossible de charger l'achat."));
+          }
+          final purchase = snapshot.data!;
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _HeaderInfo(purchase: purchase),
+                const SizedBox(height: 16),
+                _LineItemsList(items: purchase.items),
+                const SizedBox(height: 16),
+                _FinancialSummary(purchase: purchase),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _HeaderInfo extends StatelessWidget {
+  final PurchaseEntity purchase;
+  const _HeaderInfo({required this.purchase});
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(purchase.supplier.name,
+            style: tt.titleLarge?.copyWith(fontWeight: FontWeight.w600)),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Chip(
+              label: Text(_statusLabel(purchase.status)),
+              backgroundColor: _statusColor(purchase.status).withOpacity(0.1),
+              labelStyle: TextStyle(color: _statusColor(purchase.status)),
+              side: BorderSide(color: _statusColor(purchase.status)),
+            ),
+            const SizedBox(width: 8),
+            Text('Créé: ${_d(purchase.createdAt)}'),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Text('Entrepôt: ${purchase.warehouse.name}'),
+      ],
+    );
+  }
+}
+
+class _LineItemsList extends StatelessWidget {
+  final List<PurchaseLineEntity> items;
+  const _LineItemsList({required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        columns: const [
+          DataColumn(label: Text('Article')),
+          DataColumn(label: Text('Qté')),
+          DataColumn(label: Text('PU')),
+          DataColumn(label: Text('Total')),
+        ],
+        rows: items
+            .map(
+              (i) => DataRow(
+                cells: [
+                  DataCell(Text(i.name)),
+                  DataCell(Text(i.qty.toStringAsFixed(0))),
+                  DataCell(Text(_money(i.unitPrice))),
+                  DataCell(Text(_money(i.lineTotal))),
+                ],
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}
+
+class _FinancialSummary extends StatelessWidget {
+  final PurchaseEntity purchase;
+  const _FinancialSummary({required this.purchase});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _summaryRow('Sous-total', purchase.subTotal),
+        _summaryRow('Frais de port', purchase.shippingFees),
+        _summaryRow('Autres frais', purchase.otherFees),
+        _summaryRow('TVA', purchase.taxTotal),
+        const Divider(),
+        _summaryRow('Total', purchase.grandTotal, isBold: true),
+      ],
+    );
+  }
+
+  Widget _summaryRow(String label, double value, {bool isBold = false}) {
+    final style =
+        isBold ? const TextStyle(fontWeight: FontWeight.bold) : const TextStyle();
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: style),
+          Text(_money(value), style: style),
+        ],
+      ),
+    );
+  }
+}
+
+String _d(DateTime d) => DateFormat('dd/MM/yyyy', 'fr_FR').format(d);
+String _money(double v) =>
+    NumberFormat.currency(locale: 'fr_FR', symbol: 'F', decimalDigits: 0)
+        .format(v);
+
+Color _statusColor(PurchaseStatus s) {
+  switch (s) {
+    case PurchaseStatus.draft:
+      return Colors.grey;
+    case PurchaseStatus.approved:
+      return Colors.blue;
+    case PurchaseStatus.sent:
+      return Colors.indigo;
+    case PurchaseStatus.partial:
+      return Colors.orange;
+    case PurchaseStatus.received:
+      return Colors.teal;
+    case PurchaseStatus.invoiced:
+      return Colors.purple;
+    case PurchaseStatus.paid:
+      return Colors.green;
+  }
+}
+
+String _statusLabel(PurchaseStatus s) {
+  switch (s) {
+    case PurchaseStatus.draft:
+      return 'Brouillon';
+    case PurchaseStatus.approved:
+      return 'Validée';
+    case PurchaseStatus.sent:
+      return 'Envoyée';
+    case PurchaseStatus.partial:
+      return 'Réception partielle';
+    case PurchaseStatus.received:
+      return 'Réceptionnée';
+    case PurchaseStatus.invoiced:
+      return 'Facturée';
+    case PurchaseStatus.paid:
+      return 'Payée';
+  }
+}
+

--- a/lib/features/purchases/presentation/screens/purchase_detail_screen.dart
+++ b/lib/features/purchases/presentation/screens/purchase_detail_screen.dart
@@ -1,3 +1,5 @@
+// lib/features/purchases/presentation/screens/purchase_detail_screen.dart
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -17,19 +19,28 @@ class PurchaseDetailScreen extends StatefulWidget {
   State<PurchaseDetailScreen> createState() => _PurchaseDetailScreenState();
 }
 
-class _PurchaseDetailScreenState extends State<PurchaseDetailScreen> {
+class _PurchaseDetailScreenState extends State<PurchaseDetailScreen>
+    with SingleTickerProviderStateMixin {
   late final GetPurchaseDetails _getPurchaseDetails;
   Future<PurchaseEntity?>? _purchaseFuture;
+  late final TabController _tabController;
 
   @override
   void initState() {
     super.initState();
+    _tabController = TabController(length: 2, vsync: this);
     final remoteDataSource =
         PurchaseRemoteDataSourceImpl(firestore: FirebaseFirestore.instance);
     final repository =
         PurchaseRepositoryImpl(remoteDataSource: remoteDataSource);
     _getPurchaseDetails = GetPurchaseDetails(repository);
     _purchaseFuture = _loadPurchase();
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
   }
 
   Future<PurchaseEntity?> _loadPurchase() async {
@@ -48,8 +59,12 @@ class _PurchaseDetailScreenState extends State<PurchaseDetailScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.white,
       appBar: AppBar(
         title: const Text("Détail de l'achat"),
+        backgroundColor: Colors.white,
+        elevation: 0.8,
+        surfaceTintColor: Colors.transparent,
       ),
       body: FutureBuilder<PurchaseEntity?>(
         future: _purchaseFuture,
@@ -59,21 +74,32 @@ class _PurchaseDetailScreenState extends State<PurchaseDetailScreen> {
           }
           if (snapshot.hasError || !snapshot.hasData || snapshot.data == null) {
             return const Center(
-                child: Text("Impossible de charger l'achat."));
+                child: Text("Impossible de charger les détails de l'achat."));
           }
           final purchase = snapshot.data!;
-          return SingleChildScrollView(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _HeaderInfo(purchase: purchase),
-                const SizedBox(height: 16),
-                _LineItemsList(items: purchase.items),
-                const SizedBox(height: 16),
-                _FinancialSummary(purchase: purchase),
-              ],
-            ),
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                child: _PurchaseHeader(purchase: purchase),
+              ),
+              TabBar(
+                controller: _tabController,
+                tabs: const [
+                  Tab(text: 'Aperçu'),
+                  Tab(text: 'Paiements'),
+                ],
+              ),
+              Expanded(
+                child: TabBarView(
+                  controller: _tabController,
+                  children: [
+                    _OverviewTab(purchase: purchase),
+                    _PaymentsTab(purchase: purchase),
+                  ],
+                ),
+              ),
+            ],
           );
         },
       ),
@@ -81,145 +107,303 @@ class _PurchaseDetailScreenState extends State<PurchaseDetailScreen> {
   }
 }
 
-class _HeaderInfo extends StatelessWidget {
+// =========================================================================
+// WIDGETS DÉCOUPÉS
+// =========================================================================
+
+// ✅ --- MODIFICATION MAJEURE ---
+// L'en-tête inclut maintenant les informations de date, ETA et entrepôt.
+class _PurchaseHeader extends StatelessWidget {
   final PurchaseEntity purchase;
-  const _HeaderInfo({required this.purchase});
+  const _PurchaseHeader({required this.purchase});
 
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
-    return Column(
+
+    return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(purchase.supplier.name,
-            style: tt.titleLarge?.copyWith(fontWeight: FontWeight.w600)),
-        const SizedBox(height: 8),
-        Row(
-          children: [
-            Chip(
-              label: Text(_statusLabel(purchase.status)),
-              backgroundColor: _statusColor(purchase.status).withOpacity(0.1),
-              labelStyle: TextStyle(color: _statusColor(purchase.status)),
-              side: BorderSide(color: _statusColor(purchase.status)),
-            ),
-            const SizedBox(width: 8),
-            Text('Créé: ${_d(purchase.createdAt)}'),
-          ],
+        CircleAvatar(
+          radius: 26,
+          backgroundColor: cs.primary.withOpacity(0.10),
+          child: const Icon(Icons.receipt_long_outlined, size: 26),
         ),
-        const SizedBox(height: 4),
-        Text('Entrepôt: ${purchase.warehouse.name}'),
-      ],
-    );
-  }
-}
-
-class _LineItemsList extends StatelessWidget {
-  final List<PurchaseLineEntity> items;
-  const _LineItemsList({required this.items});
-
-  @override
-  Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: DataTable(
-        columns: const [
-          DataColumn(label: Text('Article')),
-          DataColumn(label: Text('Qté')),
-          DataColumn(label: Text('PU')),
-          DataColumn(label: Text('Total')),
-        ],
-        rows: items
-            .map(
-              (i) => DataRow(
-                cells: [
-                  DataCell(Text(i.name)),
-                  DataCell(Text(i.qty.toStringAsFixed(0))),
-                  DataCell(Text(_money(i.unitPrice))),
-                  DataCell(Text(_money(i.lineTotal))),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(purchase.supplier.name,
+                  style: tt.titleLarge?.copyWith(fontWeight: FontWeight.w700)),
+              const SizedBox(height: 6),
+              // --- INFOS COMPACTES AJOUTÉES ICI ---
+              Row(
+                children: [
+                  Icon(Icons.calendar_today_outlined, size: 14, color: cs.outline),
+                  const SizedBox(width: 4),
+                  Text('Cmd: ${_d(purchase.createdAt)}', style: tt.bodySmall?.copyWith(color: cs.outline)),
+                  const Text(' • ', style: TextStyle(color: Colors.grey)),
+                  Icon(Icons.event_available_outlined, size: 14, color: cs.outline),
+                  const SizedBox(width: 4),
+                  Text('ETA: ${_d(purchase.eta)}', style: tt.bodySmall?.copyWith(color: cs.outline)),
                 ],
               ),
-            )
-            .toList(),
-      ),
+               const SizedBox(height: 4),
+              Row(
+                children: [
+                  Icon(Icons.home_work_outlined, size: 14, color: cs.outline),
+                  const SizedBox(width: 4),
+                  Expanded(
+                    child: Text(
+                      purchase.warehouse.name,
+                      style: tt.bodySmall?.copyWith(color: cs.outline),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              // --- FIN DES INFOS COMPACTES ---
+              Wrap(
+                spacing: 8.0,
+                runSpacing: 4.0,
+                children: [
+                  _StatusBadge(status: purchase.status),
+                  _ChipInfo(
+                    icon: Icons.paid_outlined,
+                    label: 'Solde dû',
+                    value: _money(purchase.balanceDue),
+                    color: purchase.balanceDue > 0.01 ? Colors.orange : Colors.green,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }
 
-class _FinancialSummary extends StatelessWidget {
+
+// ✅ --- MODIFICATION ---
+// La section "Informations" a été retirée d'ici.
+class _OverviewTab extends StatelessWidget {
   final PurchaseEntity purchase;
-  const _FinancialSummary({required this.purchase});
+  const _OverviewTab({required this.purchase});
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+    final theme = Theme.of(context);
+    final items = purchase.items;
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 24),
       children: [
-        _summaryRow('Sous-total', purchase.subTotal),
-        _summaryRow('Frais de port', purchase.shippingFees),
-        _summaryRow('Autres frais', purchase.otherFees),
-        _summaryRow('TVA', purchase.taxTotal),
-        const Divider(),
-        _summaryRow('Total', purchase.grandTotal, isBold: true),
+        // --- 1. Articles commandés ---
+        const _SectionTitle(title: 'Articles commandés'),
+        const SizedBox(height: 12),
+
+        if (items.isEmpty)
+          const Center(child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 24.0),
+            child: Text("Aucun article dans cette commande."),
+          ))
+        else
+          ListView.separated(
+            shrinkWrap: true,
+            primary: false,
+            itemCount: items.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 10),
+            itemBuilder: (context, index) {
+              final item = items[index];
+              return Container(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  border: Border.all(color: theme.colorScheme.outlineVariant.withAlpha(128)),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: ListTile(
+                  leading: CircleAvatar(child: Text(item.qty.toStringAsFixed(0))),
+                  title: Text(item.name, style: const TextStyle(fontWeight: FontWeight.w600)),
+                  subtitle: Text('PU: ${_money(item.unitPrice)}'),
+                  trailing: Text(_money(item.lineTotal), style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold)),
+                ),
+              );
+            },
+          ),
+        
+        const Divider(height: 32),
+
+        // --- 2. Résumé financier ---
+        const _SectionTitle(title: 'Résumé Financier'),
+        const SizedBox(height: 12),
+        _FinancialSummaryLine(label: 'Sous-total', value: _money(purchase.subTotal)),
+        _FinancialSummaryLine(label: 'Frais de port', value: _money(purchase.shippingFees)),
+        _FinancialSummaryLine(label: 'TVA', value: _money(purchase.taxTotal)),
+        const SizedBox(height: 8),
+        _FinancialSummaryLine(label: 'Total Général', value: _money(purchase.grandTotal), isBold: true),
       ],
     );
   }
+}
 
-  Widget _summaryRow(String label, double value, {bool isBold = false}) {
-    final style =
-        isBold ? const TextStyle(fontWeight: FontWeight.bold) : const TextStyle();
+class _PaymentsTab extends StatelessWidget {
+  final PurchaseEntity purchase;
+  const _PaymentsTab({required this.purchase});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final payments = purchase.payments;
+    if (payments.isEmpty) {
+      return const Center(child: Text("Aucun paiement enregistré."));
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+      itemCount: payments.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 10),
+      itemBuilder: (context, index) {
+        final payment = payments[index];
+        return Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            border: Border.all(color: theme.colorScheme.outlineVariant.withAlpha(128)),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: ListTile(
+            leading: const CircleAvatar(child: Icon(Icons.check)),
+            title: Text(_money(payment.amount), style: const TextStyle(fontWeight: FontWeight.w600)),
+            subtitle: Text('Via ${payment.paymentMethod.name}'),
+            trailing: Text(_d(payment.date)),
+          ),
+        );
+      },
+    );
+  }
+}
+
+
+// ===== Petits widgets de présentation =====
+
+class _FinancialSummaryLine extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool isBold;
+
+  const _FinancialSummaryLine({
+    required this.label,
+    required this.value,
+    this.isBold = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 2),
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(label, style: style),
-          Text(_money(value), style: style),
+          Text(label, style: textTheme.bodyLarge),
+          Text(
+            value,
+            style: isBold 
+              ? textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold)
+              : textTheme.bodyLarge,
+          ),
         ],
       ),
     );
   }
 }
 
-String _d(DateTime d) => DateFormat('dd/MM/yyyy', 'fr_FR').format(d);
-String _money(double v) =>
-    NumberFormat.currency(locale: 'fr_FR', symbol: 'F', decimalDigits: 0)
-        .format(v);
+class _SectionTitle extends StatelessWidget {
+  final String title;
+  const _SectionTitle({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(title, style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700));
+  }
+}
+
+class _ChipInfo extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final Color? color;
+  const _ChipInfo({required this.icon, required this.label, required this.value, this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final c = color ?? cs.primary;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: c.withAlpha(25),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: c.withAlpha(89)),
+      ),
+      child: Row(mainAxisSize: MainAxisSize.min, children: [
+          Icon(icon, size: 16, color: c),
+          const SizedBox(width: 6),
+          Text('$label: $value', style: Theme.of(context).textTheme.labelMedium?.copyWith(color: c)),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  final PurchaseStatus status;
+  const _StatusBadge({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _statusColor(status);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withAlpha(25),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color),
+      ),
+      child: Text(_statusLabel(status), style: Theme.of(context).textTheme.labelMedium?.copyWith(color: color, fontWeight: FontWeight.w600)),
+    );
+  }
+}
+
+// =========================================================================
+// HELPERS
+// =========================================================================
+
+String _d(DateTime d) => DateFormat('dd/MM/yy', 'fr_FR').format(d); // Date format shortened
+String _money(double v) => NumberFormat.currency(locale: 'fr_FR', symbol: 'F', decimalDigits: 0).format(v);
 
 Color _statusColor(PurchaseStatus s) {
   switch (s) {
-    case PurchaseStatus.draft:
-      return Colors.grey;
-    case PurchaseStatus.approved:
-      return Colors.blue;
-    case PurchaseStatus.sent:
-      return Colors.indigo;
-    case PurchaseStatus.partial:
-      return Colors.orange;
-    case PurchaseStatus.received:
-      return Colors.teal;
-    case PurchaseStatus.invoiced:
-      return Colors.purple;
-    case PurchaseStatus.paid:
-      return Colors.green;
+    case PurchaseStatus.draft: return Colors.grey;
+    case PurchaseStatus.approved: return Colors.blue;
+    case PurchaseStatus.sent: return Colors.indigo;
+    case PurchaseStatus.partial: return Colors.orange;
+    case PurchaseStatus.received: return Colors.teal;
+    case PurchaseStatus.invoiced: return Colors.purple;
+    case PurchaseStatus.paid: return Colors.green;
   }
 }
 
 String _statusLabel(PurchaseStatus s) {
   switch (s) {
-    case PurchaseStatus.draft:
-      return 'Brouillon';
-    case PurchaseStatus.approved:
-      return 'Validée';
-    case PurchaseStatus.sent:
-      return 'Envoyée';
-    case PurchaseStatus.partial:
-      return 'Réception partielle';
-    case PurchaseStatus.received:
-      return 'Réceptionnée';
-    case PurchaseStatus.invoiced:
-      return 'Facturée';
-    case PurchaseStatus.paid:
-      return 'Payée';
+    case PurchaseStatus.draft: return 'Brouillon';
+    case PurchaseStatus.approved: return 'Validée';
+    case PurchaseStatus.sent: return 'Envoyée';
+    case PurchaseStatus.partial: return 'Réception partielle';
+    case PurchaseStatus.received: return 'Réceptionnée';
+    case PurchaseStatus.invoiced: return 'Facturée';
+    case PurchaseStatus.paid: return 'Payée';
   }
 }
-

--- a/lib/features/purchases/presentation/screens/purchases_list_screen.dart
+++ b/lib/features/purchases/presentation/screens/purchases_list_screen.dart
@@ -10,6 +10,7 @@ import '../../domain/entities/purchase_entity.dart';
 import '../../domain/usecases/get_all_purchases.dart';
 
 import 'create_purchase_screen.dart';
+import 'purchase_detail_screen.dart';
 
 // L'enum de filtre reste local à cet écran
 enum _FilterStatus { paid, unpaid, draft }
@@ -251,7 +252,13 @@ class _OrdersTabState extends State<_OrdersTab>
                 final p = list[i];
                 final color = _statusColor(p.status);
                 return InkWell(
-                  onTap: () {},
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => PurchaseDetailScreen(purchaseId: p.id),
+                      ),
+                    );
+                  },
                   borderRadius: BorderRadius.circular(14),
                   child: Container(
                     padding: const EdgeInsets.all(12),


### PR DESCRIPTION
## Summary
- fetch purchase details from Firestore including line items
- add purchase detail screen showing header, items and totals
- allow navigation from purchases list to detail screen

## Testing
- ⚠️ `dart format lib/features/purchases/data/datasources/remote_datasource.dart lib/features/purchases/data/repositories/purchase_repository_impl.dart lib/features/purchases/presentation/screens/purchase_detail_screen.dart lib/features/purchases/presentation/screens/purchases_list_screen.dart` (command not found: dart)
- ⚠️ `dart analyze` (command not found: dart)


------
https://chatgpt.com/codex/tasks/task_e_68be8d4fa338832dbf68f30d3abaee62