### PR TITLE
Refactor warehouses loading to provider

### DIFF
--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -1,0 +1,21 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/datasources/settings_remote_datasource.dart';
+import '../../data/repositories/settings_repository_impl.dart';
+import '../../domain/entities/management_entities.dart';
+import '../../domain/usecases/get_management_data.dart';
+import '../../../../core/providers/auth_providers.dart';
+
+/// Provider that exposes a [Future] list of [Warehouse] for the current organization.
+final warehousesProvider = FutureProvider<List<Warehouse>>((ref) async {
+  final organizationId = ref.watch(organizationIdProvider).value;
+  if (organizationId == null) {
+    return [];
+  }
+  final remoteDataSource =
+      SettingsRemoteDataSourceImpl(firestore: FirebaseFirestore.instance);
+  final repository = SettingsRepositoryImpl(remoteDataSource: remoteDataSource);
+  final getWarehouses = GetWarehouses(repository);
+  return getWarehouses(organizationId);
+});


### PR DESCRIPTION
## Summary
- add settings_providers with warehousesProvider
- refactor warehouses list screen to use provider and invalidate after changes
- controller already accepts organization ID from caller

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6ea8a040832d9f49f36092188efd