### PR TITLE
Refactor purchase payment dialog into bottom sheet

### DIFF
--- a/lib/features/purchases/presentation/screens/create_purchase_screen.dart
+++ b/lib/features/purchases/presentation/screens/create_purchase_screen.dart
@@ -262,7 +262,7 @@ class _CreatePurchaseScreenState extends ConsumerState<CreatePurchaseScreen> {
                               onAddPayment: () async {
                                 final gt = _items.fold<double>(
                                     0.0, (t, i) => t + i.lineTotal.toDouble());
-                                final res = await showAddPaymentDialog(
+                                final res = await showAddPaymentBottomSheet(
                                     context: context,
                                     currency: _currency,
                                     grandTotal: gt,

--- a/lib/features/purchases/presentation/widgets/create_purchase/add_payment_dialog.dart
+++ b/lib/features/purchases/presentation/widgets/create_purchase/add_payment_dialog.dart
@@ -3,17 +3,18 @@ import 'package:flutter/material.dart';
 import '../../../../settings/domain/entities/management_entities.dart';
 import '../../models/payment_view_model.dart';
 
-Future<PaymentViewModel?> showAddPaymentDialog({
+Future<PaymentViewModel?> showAddPaymentBottomSheet({
   required BuildContext context,
   required String currency,
   required double grandTotal,
   required List<PaymentViewModel> existingPayments,
   required List<PaymentMethod> paymentMethods,
 }) {
-  return showDialog<PaymentViewModel>(
+  return showModalBottomSheet<PaymentViewModel>(
     context: context,
+    isScrollControlled: true,
     builder: (context) {
-      return _AddPaymentDialogContent(
+      return _AddPaymentBottomSheetContent(
         currency: currency,
         grandTotal: grandTotal,
         existingPayments: existingPayments,
@@ -23,14 +24,13 @@ Future<PaymentViewModel?> showAddPaymentDialog({
   );
 }
 
-// ✅ Nouveau widget interne pour gérer l'état du dialogue
-class _AddPaymentDialogContent extends StatefulWidget {
+class _AddPaymentBottomSheetContent extends StatefulWidget {
   final String currency;
   final double grandTotal;
   final List<PaymentViewModel> existingPayments;
   final List<PaymentMethod> paymentMethods;
 
-  const _AddPaymentDialogContent({
+  const _AddPaymentBottomSheetContent({
     required this.currency,
     required this.grandTotal,
     required this.existingPayments,
@@ -38,11 +38,12 @@ class _AddPaymentDialogContent extends StatefulWidget {
   });
 
   @override
-  State<_AddPaymentDialogContent> createState() =>
-      _AddPaymentDialogContentState();
+  State<_AddPaymentBottomSheetContent> createState() =>
+      _AddPaymentBottomSheetContentState();
 }
 
-class _AddPaymentDialogContentState extends State<_AddPaymentDialogContent> {
+class _AddPaymentBottomSheetContentState
+    extends State<_AddPaymentBottomSheetContent> {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _amountController;
   PaymentMethod? _selectedMethod;
@@ -79,66 +80,78 @@ class _AddPaymentDialogContentState extends State<_AddPaymentDialogContent> {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      title: const Text('Ajouter un paiement'),
-      // ✅ Ajout du SingleChildScrollView pour éviter le "RenderFlex overflow"
-      content: SingleChildScrollView(
-        child: Form(
-          key: _formKey,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextFormField(
-                controller: _amountController,
-                decoration: InputDecoration(
-                  labelText: 'Montant',
-                  suffixText: widget.currency,
-                  border: const OutlineInputBorder(),
+    final bottom = MediaQuery.of(context).viewInsets.bottom;
+    return Padding(
+      padding: EdgeInsets.only(bottom: bottom),
+      child: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text('Ajouter un paiement',
+                    style: Theme.of(context).textTheme.titleLarge),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _amountController,
+                  decoration: InputDecoration(
+                    labelText: 'Montant',
+                    suffixText: widget.currency,
+                    border: const OutlineInputBorder(),
+                  ),
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  autofocus: true,
+                  validator: (v) {
+                    if (v == null || v.isEmpty) return 'Requis';
+                    final parsed = double.tryParse(v) ?? 0;
+                    if (parsed <= 0) return 'Montant invalide';
+                    if (parsed >
+                        (widget.grandTotal - _totalPaidSoFar) + 0.01) {
+                      return 'Dépasse le solde';
+                    }
+                    return null;
+                  },
                 ),
-                keyboardType:
-                    const TextInputType.numberWithOptions(decimal: true),
-                autofocus: true,
-                validator: (v) {
-                  if (v == null || v.isEmpty) return 'Requis';
-                  final parsed = double.tryParse(v) ?? 0;
-                  if (parsed <= 0) return 'Montant invalide';
-                  // Petite marge de 0.01 pour les erreurs de virgule flottante
-                  if (parsed > (widget.grandTotal - _totalPaidSoFar) + 0.01) {
-                    return 'Dépasse le solde';
-                  }
-                  return null;
-                },
-              ),
-              const SizedBox(height: 16),
-              DropdownButtonFormField<PaymentMethod>(
-                value: _selectedMethod,
-                decoration: const InputDecoration(
-                  labelText: 'Moyen de paiement',
-                  border: OutlineInputBorder(),
+                const SizedBox(height: 16),
+                DropdownButtonFormField<PaymentMethod>(
+                  value: _selectedMethod,
+                  decoration: const InputDecoration(
+                    labelText: 'Moyen de paiement',
+                    border: OutlineInputBorder(),
+                  ),
+                  items: widget.paymentMethods
+                      .map((method) => DropdownMenuItem(
+                            value: method,
+                            child: Text(method.name),
+                          ))
+                      .toList(),
+                  onChanged: (v) => setState(() => _selectedMethod = v),
+                  validator: (v) => v == null ? 'Requis' : null,
                 ),
-                items: widget.paymentMethods
-                    .map((method) => DropdownMenuItem(
-                          value: method,
-                          child: Text(method.name),
-                        ))
-                    .toList(),
-                onChanged: (v) => setState(() => _selectedMethod = v),
-                validator: (v) => v == null ? 'Requis' : null,
-              ),
-            ],
+                const SizedBox(height: 24),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context),
+                      child: const Text('Annuler'),
+                    ),
+                    const SizedBox(width: 8),
+                    FilledButton(
+                      onPressed: _onAdd,
+                      child: const Text('Ajouter'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('Annuler'),
-        ),
-        FilledButton(
-          onPressed: _onAdd,
-          child: const Text('Ajouter'),
-        ),
-      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- replace payment add dialog with modal bottom sheet
- adapt bottom sheet content and update screen call

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b70d3e28832db520e116fc6a111f