### PR TITLE
feat(sales): integrate clients with firebase

### DIFF
--- a/lib/features/sales/data/models/client_model.dart
+++ b/lib/features/sales/data/models/client_model.dart
@@ -1,0 +1,31 @@
+// lib/features/sales/data/models/client_model.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../domain/entities/client_entity.dart';
+
+class ClientModel extends ClientEntity {
+  const ClientModel({
+    required super.id,
+    required super.name,
+    super.phone,
+    super.address,
+  });
+
+  factory ClientModel.fromSnapshot(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return ClientModel(
+      id: doc.id,
+      name: data['name'] as String? ?? 'N/A',
+      phone: data['phone'] as String?,
+      address: data['address'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'phone': phone,
+      'address': address,
+    };
+  }
+}

--- a/lib/features/sales/data/repositories/client_repository_impl.dart
+++ b/lib/features/sales/data/repositories/client_repository_impl.dart
@@ -1,0 +1,29 @@
+// lib/features/sales/data/repositories/client_repository_impl.dart
+
+import '../../domain/entities/client_entity.dart';
+import '../../domain/repositories/client_repository.dart';
+import '../datasources/remote_datasource.dart';
+import '../models/client_model.dart';
+
+class ClientRepositoryImpl implements ClientRepository {
+  final SalesRemoteDataSource remoteDataSource;
+
+  ClientRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Stream<List<ClientEntity>> getClients(String organizationId) {
+    return remoteDataSource.getClients(organizationId);
+  }
+
+  @override
+  Future<ClientEntity> addClient(
+      String organizationId, ClientEntity client) {
+    final clientModel = ClientModel(
+      id: client.id,
+      name: client.name,
+      phone: client.phone,
+      address: client.address,
+    );
+    return remoteDataSource.addClient(organizationId, clientModel);
+  }
+}

--- a/lib/features/sales/domain/repositories/client_repository.dart
+++ b/lib/features/sales/domain/repositories/client_repository.dart
@@ -1,0 +1,9 @@
+// lib/features/sales/domain/repositories/client_repository.dart
+
+import '../entities/client_entity.dart';
+
+abstract class ClientRepository {
+  Stream<List<ClientEntity>> getClients(String organizationId);
+  Future<ClientEntity> addClient(
+      String organizationId, ClientEntity client);
+}

--- a/lib/features/sales/domain/usecases/add_client.dart
+++ b/lib/features/sales/domain/usecases/add_client.dart
@@ -1,0 +1,17 @@
+// lib/features/sales/domain/usecases/add_client.dart
+
+import '../entities/client_entity.dart';
+import '../repositories/client_repository.dart';
+
+class AddClient {
+  final ClientRepository repository;
+
+  AddClient(this.repository);
+
+  Future<ClientEntity> call({
+    required String organizationId,
+    required ClientEntity client,
+  }) {
+    return repository.addClient(organizationId, client);
+  }
+}

--- a/lib/features/sales/domain/usecases/get_clients.dart
+++ b/lib/features/sales/domain/usecases/get_clients.dart
@@ -1,0 +1,14 @@
+// lib/features/sales/domain/usecases/get_clients.dart
+
+import '../entities/client_entity.dart';
+import '../repositories/client_repository.dart';
+
+class GetClients {
+  final ClientRepository repository;
+
+  GetClients(this.repository);
+
+  Stream<List<ClientEntity>> call(String organizationId) {
+    return repository.getClients(organizationId);
+  }
+}

--- a/lib/features/sales/presentation/screens/add_client_screen.dart
+++ b/lib/features/sales/presentation/screens/add_client_screen.dart
@@ -1,17 +1,20 @@
 // lib/features/sales/presentation/screens/add_client_screen.dart
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart'; // <-- NEW IMPORT
+import '../../../../core/providers/auth_providers.dart'; // <-- NEW IMPORT
+import '../providers/sales_providers.dart'; // <-- NEW IMPORT
 
 import '../../domain/entities/client_entity.dart';
 
-class AddClientScreen extends StatefulWidget {
+class AddClientScreen extends ConsumerStatefulWidget { // <-- MODIFIED
   const AddClientScreen({super.key});
 
   @override
-  State<AddClientScreen> createState() => _AddClientScreenState();
+  ConsumerState<AddClientScreen> createState() => _AddClientScreenState(); // <-- MODIFIED
 }
 
-class _AddClientScreenState extends State<AddClientScreen> {
+class _AddClientScreenState extends ConsumerState<AddClientScreen> { // <-- MODIFIED
   final _formKey = GlobalKey<FormState>();
   final _nameController = TextEditingController();
   final _phoneController = TextEditingController();
@@ -30,24 +33,48 @@ class _AddClientScreenState extends State<AddClientScreen> {
     if (!_formKey.currentState!.validate()) return;
     setState(() => _isSaving = true);
 
-    // --- LOGIQUE FICTIVE ---
-    // Simule une sauvegarde et renvoie le nouveau client.
-    await Future.delayed(const Duration(milliseconds: 500));
-    final newClient = ClientEntity(
-      id: 'CUST-${DateTime.now().millisecondsSinceEpoch}',
-      name: _nameController.text.trim(),
-      phone: _phoneController.text.trim().isNotEmpty
-          ? _phoneController.text.trim()
-          : null,
-      address: _addressController.text.trim().isNotEmpty
-          ? _addressController.text.trim()
-          : null,
-    );
-    // --- FIN LOGIQUE FICTIVE ---
-
-    if (mounted) {
-      Navigator.of(context).pop(newClient);
+    final organizationId = ref.read(organizationIdProvider).value;
+    if (organizationId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Erreur: Organisation non trouvée.')),
+      );
+      setState(() => _isSaving = false);
+      return;
     }
+
+    // --- RÉEL SAVE LOGIC ---
+    try {
+      final addClient = ref.read(addClientProvider);
+      final newClient = ClientEntity(
+        id: '', // Firestore will generate ID
+        name: _nameController.text.trim(),
+        phone: _phoneController.text.trim().isNotEmpty
+            ? _phoneController.text.trim()
+            : null,
+        address: _addressController.text.trim().isNotEmpty
+            ? _addressController.text.trim()
+            : null,
+      );
+
+      final createdClient = await addClient(
+        organizationId: organizationId,
+        client: newClient,
+      );
+
+      ref.invalidate(clientsStreamProvider);
+
+      if (mounted) {
+        Navigator.of(context).pop(createdClient);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Erreur: $e')),
+        );
+      }
+      setState(() => _isSaving = false);
+    }
+    // --- END SAVE LOGIC ---
   }
 
   @override

--- a/lib/features/sales/presentation/screens/simple_barcode_scanner_screen.dart
+++ b/lib/features/sales/presentation/screens/simple_barcode_scanner_screen.dart
@@ -1,0 +1,88 @@
+// lib/features/sales/presentation/screens/simple_barcode_scanner_screen.dart
+
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+class SimpleBarcodeScannerScreen extends StatefulWidget {
+  const SimpleBarcodeScannerScreen({super.key});
+
+  @override
+  State<SimpleBarcodeScannerScreen> createState() =>
+      _SimpleBarcodeScannerScreenState();
+}
+
+class _SimpleBarcodeScannerScreenState
+    extends State<SimpleBarcodeScannerScreen> {
+  final MobileScannerController _cameraController = MobileScannerController();
+  bool _isTorchOn = false;
+  bool _isProcessing = false;
+
+  @override
+  void dispose() {
+    _cameraController.dispose();
+    super.dispose();
+  }
+
+  void _onDetect(BarcodeCapture capture) {
+    if (_isProcessing) return; // Évite les détections multiples
+
+    final barcode = capture.barcodes.firstOrNull;
+    if (barcode?.rawValue != null) {
+      setState(() => _isProcessing = true);
+      // On renvoie la valeur du code scanné à l'écran précédent
+      Navigator.of(context).pop(barcode!.rawValue);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Scanner un article'),
+        actions: [
+          IconButton(
+            icon: Icon(
+              _isTorchOn ? Icons.flash_on : Icons.flash_off,
+              color: _isTorchOn ? Colors.yellow.shade700 : Colors.white,
+            ),
+            onPressed: () {
+              _cameraController.toggleTorch();
+              setState(() => _isTorchOn = !_isTorchOn);
+            },
+          ),
+        ],
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+      ),
+      body: Stack(
+        children: [
+          MobileScanner(
+            controller: _cameraController,
+            onDetect: _onDetect,
+          ),
+          // Superposition visuelle pour guider l'utilisateur
+          Center(
+            child: Container(
+              width: 250,
+              height: 250,
+              decoration: BoxDecoration(
+                border: Border.all(color: Colors.white, width: 2),
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+          ),
+          const Positioned(
+            bottom: 32,
+            left: 0,
+            right: 0,
+            child: Text(
+              'Visez le code-barres ou le QR code',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.white, fontSize: 16),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/sales/presentation/widgets/create_sale/article_picker.dart
+++ b/lib/features/sales/presentation/widgets/create_sale/article_picker.dart
@@ -1,0 +1,132 @@
+// lib/features/sales/presentation/widgets/create_sale/article_picker.dart
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../../../inventory/domain/entities/article_entity.dart';
+
+
+Future<ArticleEntity?> showArticlePicker({
+  required BuildContext context,
+  required List<ArticleEntity> articles,
+}) {
+  return showModalBottomSheet<ArticleEntity>(
+    context: context,
+    useSafeArea: true,
+    isScrollControlled: true,
+    backgroundColor: Colors.white,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    showDragHandle: true,
+    builder: (context) {
+      return _ArticlePickerSheet(articles: articles);
+    },
+  );
+}
+
+class _ArticlePickerSheet extends StatefulWidget {
+  final List<ArticleEntity> articles;
+
+  const _ArticlePickerSheet({required this.articles});
+
+  @override
+  State<_ArticlePickerSheet> createState() => _ArticlePickerSheetState();
+}
+
+class _ArticlePickerSheetState extends State<_ArticlePickerSheet> {
+  late final TextEditingController _searchController;
+  late List<ArticleEntity> _filteredItems;
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController = TextEditingController();
+    _filteredItems = widget.articles;
+    _searchController.addListener(() {
+      final query = _searchController.text.toLowerCase();
+      setState(() {
+        _filteredItems = widget.articles
+            .where((item) => item.name.toLowerCase().contains(query))
+            .toList();
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  String _money(double v) =>
+      NumberFormat.currency(locale: 'fr_FR', symbol: 'F', decimalDigits: 0)
+          .format(v);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        top: 12,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text('Sélectionner un article', style: theme.textTheme.titleLarge),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _searchController,
+            decoration: InputDecoration(
+              hintText: 'Rechercher par nom...',
+              prefixIcon: const Icon(Icons.search),
+              filled: true,
+              fillColor: Colors.grey.shade100,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide.none,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Flexible(
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: _filteredItems.length,
+              itemBuilder: (context, index) {
+                final article = _filteredItems[index];
+                return Container(
+                  margin: const EdgeInsets.only(bottom: 10),
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    border: Border.all(
+                        color: theme.colorScheme.outlineVariant.withAlpha(153)),
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: ListTile(
+                    leading: CircleAvatar(
+                      radius: 20,
+                      backgroundColor:
+                          theme.colorScheme.primary.withOpacity(0.1),
+                      child: const Icon(Icons.inventory_2_outlined, size: 20),
+                    ),
+                    title: Text(article.name,
+                        style: const TextStyle(fontWeight: FontWeight.w600)),
+                    subtitle: Text('Stock: ${article.totalQuantity}'),
+                    trailing: Text(
+                      _money(article.sellPrice),
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    onTap: () => Navigator.pop(context, article),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/sales/presentation/widgets/create_sale/sale_line_dialog.dart
+++ b/lib/features/sales/presentation/widgets/create_sale/sale_line_dialog.dart
@@ -1,0 +1,134 @@
+// lib/features/sales/presentation/widgets/create_sale/sale_line_dialog.dart
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../../domain/entities/sale_line_entity.dart';
+import '../../../../inventory/domain/entities/article_entity.dart';
+
+Future<SaleLineEntity?> showSaleLineDialog({
+  required BuildContext context,
+  required ArticleEntity article,
+  SaleLineEntity? existingLine,
+}) {
+  return showDialog<SaleLineEntity>(
+    context: context,
+    builder: (context) {
+      return _SaleLineDialogContent(
+        article: article,
+        existingLine: existingLine,
+      );
+    },
+  );
+}
+
+class _SaleLineDialogContent extends StatefulWidget {
+  final ArticleEntity article;
+  final SaleLineEntity? existingLine;
+
+  const _SaleLineDialogContent({
+    required this.article,
+    this.existingLine,
+  });
+
+  @override
+  State<_SaleLineDialogContent> createState() => _SaleLineDialogContentState();
+}
+
+class _SaleLineDialogContentState extends State<_SaleLineDialogContent> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _quantityController;
+  late final TextEditingController _priceController;
+
+  @override
+  void initState() {
+    super.initState();
+    _quantityController = TextEditingController(
+        text: widget.existingLine?.quantity.toStringAsFixed(0) ?? '1');
+    _priceController = TextEditingController(
+        text: (widget.existingLine?.unitPrice ?? widget.article.sellPrice)
+            .toStringAsFixed(0));
+  }
+
+  @override
+  void dispose() {
+    _quantityController.dispose();
+    _priceController.dispose();
+    super.dispose();
+  }
+
+  void _onSave() {
+    if (!_formKey.currentState!.validate()) return;
+
+    final quantity = double.tryParse(_quantityController.text) ?? 1.0;
+    final price = double.tryParse(_priceController.text) ?? 0.0;
+
+    final newLine = SaleLineEntity(
+      id: widget.existingLine?.id ??
+          '${widget.article.id}-${DateTime.now().millisecondsSinceEpoch}',
+      productId: widget.article.id,
+      name: widget.article.name,
+      quantity: quantity,
+      unitPrice: price,
+    );
+
+    Navigator.of(context).pop(newLine);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.article.name),
+      content: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextFormField(
+              controller: _quantityController,
+              decoration: InputDecoration(
+                labelText: 'Quantité',
+                suffixText: 'en stock: ${widget.article.totalQuantity}',
+              ),
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              validator: (value) {
+                if (value == null || value.isEmpty) return 'Requis';
+                final qty = int.tryParse(value) ?? 0;
+                if (qty <= 0) return 'Doit être > 0';
+                if (qty > widget.article.totalQuantity) {
+                  return 'Stock insuffisant';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _priceController,
+              decoration: const InputDecoration(
+                labelText: 'Prix de vente unitaire',
+                suffixText: 'F CFA',
+              ),
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              validator: (value) {
+                if (value == null || value.isEmpty) return 'Requis';
+                if ((double.tryParse(value) ?? -1) < 0) return 'Prix invalide';
+                return null;
+              },
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Annuler'),
+        ),
+        FilledButton(
+          onPressed: _onSave,
+          child: const Text('Confirmer'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore-backed client model and repository
- stream and save clients through remote datasource and providers
- persist new clients and consume real lists in sale creation

## Testing
- `flutter format lib/features/sales/data/models/client_model.dart lib/features/sales/domain/repositories/client_repository.dart lib/features/sales/data/repositories/client_repository_impl.dart lib/features/sales/domain/usecases/add_client.dart lib/features/sales/domain/usecases/get_clients.dart lib/features/sales/data/datasources/remote_datasource.dart lib/features/sales/presentation/providers/sales_providers.dart lib/features/sales/presentation/screens/add_client_screen.dart lib/features/sales/presentation/screens/create_sale_screen.dart` *(failed: command not found)*
- `flutter analyze` *(failed: command not found)*
- `dart analyze` *(failed: command not found)*
- `flutter test` *(failed: command not found)*
- `dart test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4398769cc832db63af3796374546b