### PR TITLE
feat: add sale line serial scanning

### DIFF
--- a/lib/features/sales/data/models/sale_line_model.dart
+++ b/lib/features/sales/data/models/sale_line_model.dart
@@ -12,6 +12,8 @@ class SaleLineModel extends SaleLineEntity {
     super.discountType,
     super.discountValue,
     super.vatRate,
+    super.isSerialized,
+    super.scannedCodes,
   });
 
   factory SaleLineModel.fromEntity(SaleLineEntity entity) {
@@ -24,6 +26,8 @@ class SaleLineModel extends SaleLineEntity {
       discountType: entity.discountType,
       discountValue: entity.discountValue,
       vatRate: entity.vatRate,
+      isSerialized: entity.isSerialized,
+      scannedCodes: entity.scannedCodes,
     );
   }
 
@@ -38,6 +42,8 @@ class SaleLineModel extends SaleLineEntity {
           DiscountType.values.byName(json['discount_type'] as String? ?? 'none'),
       discountValue: (json['discount_value'] as num?)?.toDouble() ?? 0.0,
       vatRate: (json['vat_rate'] as num?)?.toDouble() ?? 0.0,
+      isSerialized: json['is_serialized'] as bool? ?? false,
+      scannedCodes: List<String>.from(json['scanned_codes'] ?? []),
     );
   }
 
@@ -50,6 +56,8 @@ class SaleLineModel extends SaleLineEntity {
       'discount_type': discountType.name,
       'discount_value': discountValue,
       'vat_rate': vatRate,
+      'is_serialized': isSerialized,
+      'scanned_codes': scannedCodes,
     };
   }
 }

--- a/lib/features/sales/domain/entities/sale_line_entity.dart
+++ b/lib/features/sales/domain/entities/sale_line_entity.dart
@@ -12,6 +12,10 @@ class SaleLineEntity {
   final DiscountType discountType;
   final double discountValue;
   final double vatRate;
+  // Indicates whether the item is tracked by serial number
+  final bool isSerialized;
+  // List of scanned serial codes for serialized items
+  final List<String> scannedCodes;
 
   const SaleLineEntity({
     required this.id,
@@ -22,6 +26,8 @@ class SaleLineEntity {
     this.discountType = DiscountType.none,
     this.discountValue = 0.0,
     this.vatRate = 0.0,
+    this.isSerialized = false,
+    this.scannedCodes = const [],
   });
 
   double get gross => quantity * unitPrice;

--- a/lib/features/sales/presentation/screens/sale_line_scanner_screen.dart
+++ b/lib/features/sales/presentation/screens/sale_line_scanner_screen.dart
@@ -1,0 +1,190 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+class SaleLineScannerScreen extends StatefulWidget {
+  final int targetQuantity;
+  final List<String> alreadyScannedCodes;
+  final String articleName;
+
+  const SaleLineScannerScreen({
+    super.key,
+    required this.targetQuantity,
+    required this.alreadyScannedCodes,
+    required this.articleName,
+  });
+
+  @override
+  State<SaleLineScannerScreen> createState() => _SaleLineScannerScreenState();
+}
+
+class _SaleLineScannerScreenState extends State<SaleLineScannerScreen> {
+  final MobileScannerController _cameraController = MobileScannerController();
+  late final List<String> _scannedCodes;
+  Timer? _scanDebouncer;
+  bool _isTorchOn = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scannedCodes = List.from(widget.alreadyScannedCodes);
+  }
+
+  @override
+  void dispose() {
+    _scanDebouncer?.cancel();
+    _cameraController.dispose();
+    super.dispose();
+  }
+
+  void _onDetect(BarcodeCapture capture) {
+    if (_scanDebouncer?.isActive ?? false) return;
+    _scanDebouncer = Timer(const Duration(milliseconds: 500), () {});
+
+    if (_scannedCodes.length >= widget.targetQuantity) return;
+
+    final code = capture.barcodes.firstOrNull?.rawValue;
+    if (code != null && code.trim().isNotEmpty) {
+      if (!_scannedCodes.contains(code)) {
+        setState(() {
+          _scannedCodes.add(code);
+        });
+        _showFeedback('Code ajouté !', isSuccess: true);
+      } else {
+        _showFeedback('Ce code a déjà été scanné.', isError: true);
+      }
+    }
+  }
+
+  void _removeCode(int index) {
+    setState(() {
+      _scannedCodes.removeAt(index);
+    });
+  }
+
+  void _showFeedback(String message, {bool isError = false, bool isSuccess = false}) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: isError
+            ? Colors.orange
+            : (isSuccess ? Colors.green : null),
+        duration: const Duration(seconds: 1),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isComplete =
+        _scannedCodes.length == widget.targetQuantity;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.articleName),
+        leading:
+            BackButton(onPressed: () => Navigator.of(context).pop(_scannedCodes)),
+        actions: [
+          IconButton(
+            icon: Icon(
+              _isTorchOn ? Icons.flash_on : Icons.flash_off,
+              color: _isTorchOn ? Colors.yellow.shade700 : null,
+            ),
+            onPressed: () {
+              _cameraController.toggleTorch();
+              setState(() => _isTorchOn = !_isTorchOn);
+            },
+          ),
+        ],
+      ),
+      body: Stack(
+        children: [
+          MobileScanner(
+            controller: _cameraController,
+            onDetect: _onDetect,
+          ),
+          Column(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              Container(
+                color: Colors.black.withOpacity(0.7),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Column(
+                  children: [
+                    Text(
+                      'Scannés: ${_scannedCodes.length} / ${widget.targetQuantity}',
+                      style: TextStyle(
+                        color: isComplete ? Colors.greenAccent : Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    _scannedCodes.isEmpty
+                        ? const Padding(
+                            padding: EdgeInsets.symmetric(vertical: 8.0),
+                            child: Text(
+                                'Veuillez scanner les codes...',
+                                style: TextStyle(color: Colors.white70)),
+                          )
+                        : ConstrainedBox(
+                            constraints:
+                                const BoxConstraints(maxHeight: 120),
+                            child: ListView.builder(
+                              shrinkWrap: true,
+                              itemCount: _scannedCodes.length,
+                              itemBuilder: (context, index) {
+                                return Padding(
+                                  padding:
+                                      const EdgeInsets.symmetric(vertical: 2.0),
+                                  child: Row(
+                                    children: [
+                                      Expanded(
+                                          child: Text(
+                                              "• ${_scannedCodes[index]}",
+                                              style: const TextStyle(
+                                                  color: Colors.white,
+                                                  fontSize: 12))),
+                                      IconButton(
+                                        icon: const Icon(
+                                            Icons.delete_outline,
+                                            color: Colors.redAccent,
+                                            size: 20),
+                                        onPressed: () => _removeCode(index),
+                                      )
+                                    ],
+                                  ),
+                                );
+                              },
+                            ),
+                          ),
+                  ],
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.all(20.0),
+                color: Colors.black.withOpacity(0.7),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: () =>
+                        Navigator.of(context).pop(_scannedCodes),
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      backgroundColor:
+                          isComplete ? Colors.green : Colors.blue,
+                    ),
+                    child: Text(isComplete
+                        ? 'Valider les codes'
+                        : 'Valider (${_scannedCodes.length}/${widget.targetQuantity})'),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/sales/presentation/widgets/create_sale/article_picker.dart
+++ b/lib/features/sales/presentation/widgets/create_sale/article_picker.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
-import '../../../../../core/providers/auth_providers.dart'; // ✅ IMPORT AJOUTÉ
+import '../../../../../core/providers/auth_providers.dart';
 import '../../../../inventory/domain/entities/article_entity.dart';
 import '../../../../inventory/presentation/providers/inventory_providers.dart';
 
@@ -17,15 +17,11 @@ final articleSearchResultsProvider =
   final query = ref.watch(articleSearchQueryProvider);
   final organizationId = ref.watch(organizationIdProvider).value;
 
-  // Si la recherche est vide ou si on n'a pas l'ID de l'orga, on ne retourne rien
   if (query.isEmpty || organizationId == null) {
     return Stream.value([]);
   }
 
-  // ✅ --- CORRECTION APPLIQUÉE ICI ---
-  // 1. On récupère le "use case" (la télécommande) pour la recherche
   final searchUseCase = ref.watch(searchArticlesProvider(query));
-  // 2. On appelle le "use case" avec les bons paramètres pour obtenir le flux
   return searchUseCase(organizationId: organizationId, query: query);
 });
 
@@ -42,7 +38,13 @@ Future<ArticleEntity?> showArticlePicker({
     ),
     showDragHandle: true,
     builder: (context) {
-      return const _ArticlePickerSheet();
+      // ✅ --- CORRECTION APPLIQUÉE ICI ---
+      // On encapsule le widget dans un Container pour lui donner une hauteur fixe.
+      return Container(
+        height: MediaQuery.of(context).size.height * 1, // 80% de la hauteur de l'écran
+        child: const _ArticlePickerSheet(),
+      );
+      // --- FIN DE LA CORRECTION ---
     },
   );
 }
@@ -66,8 +68,9 @@ class _ArticlePickerSheet extends ConsumerWidget {
         top: 12,
         bottom: MediaQuery.of(context).viewInsets.bottom + 16,
       ),
+      // ✅ --- CORRECTION APPLIQUÉE ICI ---
+      // On retire `mainAxisSize: MainAxisSize.min` pour que la Column remplisse l'espace.
       child: Column(
-        mainAxisSize: MainAxisSize.min,
         children: [
           Text('Sélectionner un article', style: theme.textTheme.titleLarge),
           const SizedBox(height: 16),
@@ -87,7 +90,9 @@ class _ArticlePickerSheet extends ConsumerWidget {
             ),
           ),
           const SizedBox(height: 16),
-          Flexible(
+          // ✅ --- MODIFICATION ---
+          // On utilise Expanded pour que la zone de résultats prenne toute la place restante.
+          Expanded(
             child: searchResults.when(
               data: (articles) {
                 if (articles.isEmpty &&
@@ -99,7 +104,7 @@ class _ArticlePickerSheet extends ConsumerWidget {
                   return const Center(child: Text("Aucun article trouvé."));
                 }
                 return ListView.builder(
-                  shrinkWrap: true,
+                  // On retire shrinkWrap car la hauteur est maintenant gérée par Expanded
                   itemCount: articles.length,
                   itemBuilder: (context, index) {
                     final article = articles[index];

--- a/lib/features/sales/presentation/widgets/create_sale/confirm_exit_dialog.dart
+++ b/lib/features/sales/presentation/widgets/create_sale/confirm_exit_dialog.dart
@@ -1,0 +1,27 @@
+// lib/features/sales/presentation/widgets/create_sale/confirm_exit_dialog.dart
+
+import 'package:flutter/material.dart';
+
+/// Affiche une boîte de dialogue pour confirmer que l'utilisateur veut
+/// quitter l'écran et perdre les données saisies.
+Future<bool> confirmSaleExit(BuildContext context) async {
+  return await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Abandonner la vente ?'),
+          content: const Text('Toutes les données saisies pour cette vente seront perdues.'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Rester'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(context, true),
+              style: FilledButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.error),
+              child: const Text('Abandonner'),
+            ),
+          ],
+        ),
+      ) ??
+      false;
+}

--- a/lib/features/sales/presentation/widgets/create_sale/sale_line_dialog.dart
+++ b/lib/features/sales/presentation/widgets/create_sale/sale_line_dialog.dart
@@ -69,6 +69,9 @@ class _SaleLineDialogContentState extends State<_SaleLineDialogContent> {
       name: widget.article.name,
       quantity: quantity,
       unitPrice: price,
+      // Serialized info
+      isSerialized: widget.article.hasSerializedUnits,
+      scannedCodes: widget.existingLine?.scannedCodes ?? [],
     );
 
     Navigator.of(context).pop(newLine);
@@ -86,7 +89,8 @@ class _SaleLineDialogContentState extends State<_SaleLineDialogContent> {
             TextFormField(
               controller: _quantityController,
               decoration: InputDecoration(
-                labelText: 'Quantité',
+                labelText:
+                    widget.article.hasSerializedUnits ? 'Quantité à vendre' : 'Quantité',
                 suffixText: 'en stock: ${widget.article.totalQuantity}',
               ),
               keyboardType: TextInputType.number,


### PR DESCRIPTION
## Summary
- add serial number scanner screen for sale lines
- track serialized sale items and scanned codes in entities and models
- integrate code scanning and validation in sale creation flow

## Testing
- `flutter format lib/features/sales/domain/entities/sale_line_entity.dart lib/features/sales/data/models/sale_line_model.dart lib/features/sales/presentation/widgets/create_sale/sale_line_dialog.dart lib/features/sales/presentation/screens/create_sale_screen.dart lib/features/sales/presentation/screens/sale_line_scanner_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c45a524438832db21bdaaa18caaddf