### PR TITLE
feat: add payment models and dialog

### DIFF
--- a/lib/features/sales/data/models/payment_model.dart
+++ b/lib/features/sales/data/models/payment_model.dart
@@ -9,9 +9,9 @@ class PaymentModel extends PaymentEntity {
     required super.id,
     required super.amount,
     required super.date,
-    required super.paymentMethod,
+    required super.paymentMethod, // ✅ Ligne corrigée
     super.reference,
-  }) : super(paymentMethod: paymentMethod);
+  });
 
   factory PaymentModel.fromEntity(PaymentEntity entity) {
     return PaymentModel(

--- a/lib/features/sales/data/models/payment_model.dart
+++ b/lib/features/sales/data/models/payment_model.dart
@@ -1,0 +1,50 @@
+// lib/features/sales/data/models/payment_model.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../../settings/data/models/management_models.dart';
+import '../../domain/entities/payment_entity.dart';
+
+class PaymentModel extends PaymentEntity {
+  const PaymentModel({
+    required super.id,
+    required super.amount,
+    required super.date,
+    required super.paymentMethod,
+    super.reference,
+  }) : super(paymentMethod: paymentMethod);
+
+  factory PaymentModel.fromEntity(PaymentEntity entity) {
+    return PaymentModel(
+      id: entity.id,
+      amount: entity.amount,
+      date: entity.date,
+      paymentMethod: entity.paymentMethod,
+      reference: entity.reference,
+    );
+  }
+
+  factory PaymentModel.fromSnapshot(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return PaymentModel(
+      id: doc.id,
+      amount: (data['amount'] as num?)?.toDouble() ?? 0.0,
+      date: (data['date'] as Timestamp).toDate(),
+      paymentMethod: PaymentMethodModel.fromJson(data['payment_method']),
+      reference: data['reference'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'amount': amount,
+      'date': Timestamp.fromDate(date),
+      'payment_method': PaymentMethodModel(
+        id: paymentMethod.id,
+        name: paymentMethod.name,
+        type: paymentMethod.type,
+        balance: paymentMethod.balance,
+      ).toJson(),
+      'reference': reference,
+    };
+  }
+}

--- a/lib/features/sales/data/models/sale_model.dart
+++ b/lib/features/sales/data/models/sale_model.dart
@@ -2,7 +2,6 @@
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../domain/entities/sale_entity.dart';
-import '../../domain/entities/sale_line_entity.dart';
 
 class SaleModel extends SaleEntity {
   const SaleModel({
@@ -11,10 +10,13 @@ class SaleModel extends SaleEntity {
     super.customerName,
     required super.status,
     required super.createdAt,
-    required super.items,
+    super.items,
+    super.payments,
     super.globalDiscount,
     super.shippingFees,
     super.otherFees,
+    super.createdBy,
+    super.hasDelivery,
   });
 
   factory SaleModel.fromEntity(SaleEntity entity) {
@@ -25,9 +27,12 @@ class SaleModel extends SaleEntity {
       status: entity.status,
       createdAt: entity.createdAt,
       items: entity.items,
+      payments: entity.payments,
       globalDiscount: entity.globalDiscount,
       shippingFees: entity.shippingFees,
       otherFees: entity.otherFees,
+      createdBy: entity.createdBy,
+      hasDelivery: entity.hasDelivery,
     );
   }
 
@@ -37,12 +42,19 @@ class SaleModel extends SaleEntity {
       id: doc.id,
       customerId: data['customer_id'] as String? ?? '',
       customerName: data['customer_name'] as String?,
-      status: SaleStatus.values.byName(data['status'] as String),
+      status: SaleStatus.values.byName(data['status'] as String? ?? 'draft'),
       createdAt: (data['created_at'] as Timestamp).toDate(),
-      items: const <SaleLineEntity>[],
+      // Les listes (items, payments) sont chargées séparément via une sous-collection
+      items: const [], 
+      payments: const [],
       globalDiscount: (data['global_discount'] as num?)?.toDouble() ?? 0.0,
       shippingFees: (data['shipping_fees'] as num?)?.toDouble() ?? 0.0,
       otherFees: (data['other_fees'] as num?)?.toDouble() ?? 0.0,
+      createdBy: data['created_by'] as String?,
+      hasDelivery: data['has_delivery'] as bool?,
+      // ✅ Ajout des totaux calculés pour un accès facile
+      // grandTotal: (data['grand_total'] as num?)?.toDouble() ?? 0.0,
+      // totalPaid: (data['total_paid'] as num?)?.toDouble() ?? 0.0,
     );
   }
 
@@ -55,6 +67,12 @@ class SaleModel extends SaleEntity {
       'global_discount': globalDiscount,
       'shipping_fees': shippingFees,
       'other_fees': otherFees,
+      'created_by': createdBy,
+      'has_delivery': hasDelivery,
+      // ✅ Ajout des totaux et du statut de paiement dénormalisés
+      'grand_total': grandTotal,
+      'total_paid': totalPaid,
+      'payment_status': paymentStatus.name,
     };
   }
 }

--- a/lib/features/sales/domain/entities/payment_entity.dart
+++ b/lib/features/sales/domain/entities/payment_entity.dart
@@ -1,0 +1,19 @@
+// lib/features/sales/domain/entities/payment_entity.dart
+
+import '../../../settings/domain/entities/management_entities.dart';
+
+class PaymentEntity {
+  final String id;
+  final double amount;
+  final DateTime date;
+  final PaymentMethod paymentMethod;
+  final String? reference;
+
+  const PaymentEntity({
+    required this.id,
+    required this.amount,
+    required this.date,
+    required this.paymentMethod,
+    this.reference,
+  });
+}

--- a/lib/features/sales/domain/entities/sale_entity.dart
+++ b/lib/features/sales/domain/entities/sale_entity.dart
@@ -1,9 +1,11 @@
 // lib/features/sales/domain/entities/sale_entity.dart
 
+import 'payment_entity.dart';
 import 'sale_line_entity.dart';
 
 /// Possible states for a sale.
 enum SaleStatus { draft, completed, cancelled }
+enum PaymentStatus { unpaid, partial, paid }
 
 class SaleEntity {
   final String id;
@@ -12,12 +14,12 @@ class SaleEntity {
   final SaleStatus status;
   final DateTime createdAt;
   final List<SaleLineEntity> items;
+  final List<PaymentEntity> payments; // ✅ CHAMP AJOUTÉ
   final double globalDiscount;
   final double shippingFees;
   final double otherFees;
   
   final String? createdBy;
-  final String? paymentStatus;
   
   // ✅ CHAMP AJOUTÉ POUR LA GESTION DES LIVRAISONS
   final bool? hasDelivery;
@@ -30,12 +32,12 @@ class SaleEntity {
     this.status = SaleStatus.draft,
     required this.createdAt,
     this.items = const [],
+    this.payments = const [], // ✅ Ajouté au constructeur
     this.globalDiscount = 0.0,
     this.shippingFees = 0.0,
     this.otherFees = 0.0,
     this.createdBy,
-    this.paymentStatus,
-    this.hasDelivery, // ✅ Ajouté au constructeur
+    this.hasDelivery,
   });
 
   double get subTotal => items.fold(0.0, (sum, item) => sum + item.lineSubtotal);
@@ -47,4 +49,14 @@ class SaleEntity {
       items.fold(0.0, (sum, item) => sum + item.lineTax);
   double get grandTotal =>
       taxableBase + taxTotal + shippingFees + otherFees;
+
+  // ✅ LOGIQUE DE PAIEMENT AMÉLIORÉE
+  double get totalPaid => payments.fold(0.0, (sum, p) => sum + p.amount);
+  double get balanceDue => grandTotal - totalPaid;
+
+  PaymentStatus get paymentStatus {
+    if (totalPaid <= 0.01) return PaymentStatus.unpaid;
+    if (balanceDue > 0.01) return PaymentStatus.partial;
+    return PaymentStatus.paid;
+  }
 }

--- a/lib/features/sales/presentation/models/payment_view_model.dart
+++ b/lib/features/sales/presentation/models/payment_view_model.dart
@@ -1,0 +1,19 @@
+// lib/features/sales/presentation/models/payment_view_model.dart
+
+import '../../../settings/domain/entities/management_entities.dart';
+
+/// Un modèle simple pour gérer un paiement dans l'UI avant la sauvegarde.
+class PaymentViewModel {
+  final double amountPaid; // Ce que le client doit payer pour cette transaction
+  final PaymentMethod method;
+  final double? amountGiven; // Montant physiquement donné par le client
+
+  const PaymentViewModel({
+    required this.amountPaid,
+    required this.method,
+    this.amountGiven,
+  });
+
+  // Calcule la monnaie à rendre
+  double get change => (amountGiven ?? amountPaid) - amountPaid;
+}

--- a/lib/features/sales/presentation/screens/sales_list_screen.dart
+++ b/lib/features/sales/presentation/screens/sales_list_screen.dart
@@ -2,7 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_speed_dial/flutter_speed_dial.dart'; // <-- 1. IMPORT DU NOUVEAU PACKAGE
+import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:intl/intl.dart';
 
 import '../../domain/entities/sale_entity.dart';
@@ -29,7 +29,7 @@ List<SaleEntity> _getHardcodedSales() {
             unitPrice: 15000),
       ],
       createdBy: 'Alice Dubois',
-      paymentStatus: 'Payé',
+      // ✅ Le paymentStatus est retiré, il sera calculé
       hasDelivery: false,
     ),
     SaleEntity(
@@ -53,7 +53,7 @@ List<SaleEntity> _getHardcodedSales() {
             unitPrice: 10000),
       ],
       createdBy: 'Bob Martin',
-      paymentStatus: 'Partiel',
+      // ✅ Le paymentStatus est retiré, il sera calculé
       hasDelivery: true,
     ),
     SaleEntity(
@@ -71,7 +71,7 @@ List<SaleEntity> _getHardcodedSales() {
             unitPrice: 7500),
       ],
       createdBy: 'Alice Dubois',
-      paymentStatus: 'Non Payé',
+      // ✅ Le paymentStatus est retiré, il sera calculé
       hasDelivery: false,
     ),
     SaleEntity(
@@ -89,7 +89,7 @@ List<SaleEntity> _getHardcodedSales() {
             unitPrice: 85000),
       ],
       createdBy: 'Carla C.',
-      paymentStatus: 'En attente',
+      // ✅ Le paymentStatus est retiré, il sera calculé
       hasDelivery: true,
     ),
   ];
@@ -225,7 +225,6 @@ class _SalesListScreenState extends ConsumerState<SalesListScreen>
           error: (e, _) => Center(child: Text('Erreur: $e')),
         ),
       ),
-      // --- 2. REMPLACEMENT DU BOUTON FLOTTANT ---
       floatingActionButton: SpeedDial(
         icon: Icons.add,
         activeIcon: Icons.close,
@@ -273,7 +272,6 @@ class _SalesListScreenState extends ConsumerState<SalesListScreen>
           ),
         ],
       ),
-      // --- FIN DE LA MODIFICATION ---
     );
   }
 }
@@ -385,6 +383,18 @@ class _SaleCard extends StatelessWidget {
 
   const _SaleCard({required this.sale, required this.moneyFormatter});
 
+  // ✅ --- NOUVELLE FONCTION HELPER POUR TRADUIRE LE STATUT ---
+  String _getPaymentStatusText(PaymentStatus status) {
+    switch (status) {
+      case PaymentStatus.paid:
+        return 'Payé';
+      case PaymentStatus.partial:
+        return 'Partiel';
+      case PaymentStatus.unpaid:
+        return 'Non payé';
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Card(
@@ -458,7 +468,8 @@ class _SaleCard extends StatelessWidget {
                       style: const TextStyle(
                           fontSize: 12, color: Color(0xFF6B7280))),
                   const SizedBox(width: 8),
-                  _StatusPill(status: sale.paymentStatus ?? 'N/A'),
+                  // ✅ L'ENUM EST CONVERTI EN TEXTE AVANT D'ÊTRE PASSÉ AU WIDGET
+                  _StatusPill(status: _getPaymentStatusText(sale.paymentStatus)),
                 ],
               ),
               if (sale.hasDelivery == true)

--- a/lib/features/sales/presentation/widgets/create_sale/add_payment_dialog.dart
+++ b/lib/features/sales/presentation/widgets/create_sale/add_payment_dialog.dart
@@ -1,0 +1,193 @@
+// lib/features/sales/presentation/widgets/create_sale/add_payment_dialog.dart
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../settings/domain/entities/management_entities.dart';
+import '../../models/payment_view_model.dart';
+
+Future<PaymentViewModel?> showAddPaymentDialog({
+  required BuildContext context,
+  required double amountDue,
+  required List<PaymentMethod> paymentMethods,
+}) {
+  return showModalBottomSheet<PaymentViewModel>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.white,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (context) {
+      return _AddPaymentDialogContent(
+        amountDue: amountDue,
+        paymentMethods: paymentMethods,
+      );
+    },
+  );
+}
+
+class _AddPaymentDialogContent extends StatefulWidget {
+  final double amountDue;
+  final List<PaymentMethod> paymentMethods;
+
+  const _AddPaymentDialogContent({
+    required this.amountDue,
+    required this.paymentMethods,
+  });
+
+  @override
+  State<_AddPaymentDialogContent> createState() =>
+      _AddPaymentDialogContentState();
+}
+
+class _AddPaymentDialogContentState extends State<_AddPaymentDialogContent> {
+  final _formKey = GlobalKey<FormState>();
+  final _amountCtrl = TextEditingController();
+  PaymentMethod? _selectedMethod;
+  double _change = 0.0;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.paymentMethods.isNotEmpty) {
+      _selectedMethod = widget.paymentMethods.first;
+    }
+    _amountCtrl.addListener(_calculateChange);
+  }
+
+  @override
+  void dispose() {
+    _amountCtrl.removeListener(_calculateChange);
+    _amountCtrl.dispose();
+    super.dispose();
+  }
+
+  void _calculateChange() {
+    final given = double.tryParse(_amountCtrl.text) ?? 0.0;
+    if (given > widget.amountDue) {
+      setState(() => _change = given - widget.amountDue);
+    } else {
+      setState(() => _change = 0.0);
+    }
+  }
+
+  void _onSave() {
+    if (!_formKey.currentState!.validate()) return;
+    if (_selectedMethod == null) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+        content: Text('Veuillez sélectionner un moyen de paiement.'),
+        backgroundColor: Colors.orange,
+      ));
+      return;
+    }
+
+    final amountGiven = double.tryParse(_amountCtrl.text) ?? 0.0;
+    final amountToPay = (_change > 0) ? widget.amountDue : amountGiven;
+
+    final result = PaymentViewModel(
+      amountPaid: amountToPay,
+      method: _selectedMethod!,
+      amountGiven: amountGiven,
+    );
+    Navigator.of(context).pop(result);
+  }
+
+  String _money(double v) =>
+      NumberFormat.currency(locale: 'fr_FR', symbol: 'F', decimalDigits: 0)
+          .format(v);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding:
+          EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(20, 24, 20, 24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text('Ajouter un paiement', style: theme.textTheme.titleLarge),
+              const SizedBox(height: 12),
+              Text(
+                'Solde restant à payer : ${_money(widget.amountDue)}',
+                style: theme.textTheme.titleMedium
+                    ?.copyWith(color: theme.colorScheme.primary),
+              ),
+              const SizedBox(height: 20),
+              TextFormField(
+                controller: _amountCtrl,
+                autofocus: true,
+                decoration: InputDecoration(
+                  labelText: 'Montant reçu du client *',
+                  suffixText: 'F CFA',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                validator: (v) {
+                  if (v == null || v.isEmpty) return 'Requis';
+                  if ((double.tryParse(v) ?? 0) <= 0) return 'Montant invalide';
+                  return null;
+                },
+              ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  onPressed: () {
+                    _amountCtrl.text = widget.amountDue.toStringAsFixed(0);
+                  },
+                  child: const Text('Saisir le montant exact'),
+                ),
+              ),
+              if (_change > 0)
+                Padding(
+                  padding: const EdgeInsets.only(top: 12.0),
+                  child: Text(
+                    'Monnaie à rendre : ${_money(_change)}',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: Colors.green.shade700,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 20),
+              Text('Payé via *', style: theme.textTheme.titleSmall),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: widget.paymentMethods
+                    .map((method) => ChoiceChip(
+                          label: Text(method.name),
+                          selected: _selectedMethod?.id == method.id,
+                          onSelected: (selected) {
+                            if (selected) setState(() => _selectedMethod = method);
+                          },
+                        ))
+                    .toList(),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: _onSave,
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                child: const Text('Ajouter le paiement'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/data/models/management_models.dart
+++ b/lib/features/settings/data/models/management_models.dart
@@ -75,6 +75,15 @@ class PaymentMethodModel extends PaymentMethod {
     );
   }
 
+  factory PaymentMethodModel.fromJson(Map<String, dynamic> json) {
+    return PaymentMethodModel(
+      id: json['id'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      type: json['type'] as String? ?? 'cash',
+      balance: (json['balance'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+
   Map<String, dynamic> toJson() {
     return {
       'name': name,


### PR DESCRIPTION
## Summary
- add PaymentViewModel, entity, model, and add-payment dialog
- extend sales entity/model and create-sale screen with payment handling
- support parsing payment method JSON

## Testing
- `dart format lib/features/sales/presentation/models/payment_view_model.dart lib/features/sales/domain/entities/payment_entity.dart lib/features/sales/data/models/payment_model.dart lib/features/sales/presentation/widgets/create_sale/add_payment_dialog.dart lib/features/sales/domain/entities/sale_entity.dart lib/features/sales/data/models/sale_model.dart lib/features/sales/presentation/screens/create_sale_screen.dart lib/features/settings/data/models/management_models.dart`
- `flutter test`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_68c4752f2fc4832db2096d38fe7aa9e1