### PR TITLE
feat: add sale payment controller

### DIFF
--- a/lib/features/sales/data/repositories/sales_repository_impl.dart
+++ b/lib/features/sales/data/repositories/sales_repository_impl.dart
@@ -1,8 +1,10 @@
 // lib/features/sales/data/repositories/sales_repository_impl.dart
 
+import '../../domain/entities/payment_entity.dart';
 import '../../domain/entities/sale_entity.dart';
 import '../../domain/repositories/sales_repository.dart';
 import '../datasources/remote_datasource.dart';
+import '../models/payment_model.dart';
 import '../models/sale_model.dart';
 
 class SalesRepositoryImpl implements SalesRepository {
@@ -33,6 +35,8 @@ class SalesRepositoryImpl implements SalesRepository {
     final (saleModel, lineModels, paymentModels) =
         await remoteDataSource.getSaleDetails(organizationId, saleId);
     if (saleModel == null) return null;
+    final payments = paymentModels.map((p) => p as PaymentEntity).toList();
+
     return SaleEntity(
       id: saleModel.id,
       customerId: saleModel.customerId,
@@ -40,7 +44,7 @@ class SalesRepositoryImpl implements SalesRepository {
       status: saleModel.status,
       createdAt: saleModel.createdAt,
       items: lineModels,
-      payments: paymentModels,
+      payments: payments,
       globalDiscount: saleModel.globalDiscount,
       shippingFees: saleModel.shippingFees,
       otherFees: saleModel.otherFees,
@@ -58,5 +62,16 @@ class SalesRepositoryImpl implements SalesRepository {
   }) {
     final model = SaleModel.fromEntity(sale);
     return remoteDataSource.updateSale(organizationId, model);
+  }
+
+  @override
+  Future<void> addPayment({
+    required String organizationId,
+    required String saleId,
+    required PaymentEntity payment,
+  }) {
+    PaymentModel.fromEntity(payment);
+    // La logique de transaction est gérée dans SaleDetailController.
+    throw UnimplementedError('Handled by SaleDetailController transaction');
   }
 }

--- a/lib/features/sales/domain/repositories/sales_repository.dart
+++ b/lib/features/sales/domain/repositories/sales_repository.dart
@@ -1,5 +1,6 @@
 // lib/features/sales/domain/repositories/sales_repository.dart
 
+import '../entities/payment_entity.dart';
 import '../entities/sale_entity.dart';
 
 abstract class SalesRepository {
@@ -22,5 +23,12 @@ abstract class SalesRepository {
   Future<SaleEntity?> getSaleDetails({
     required String organizationId,
     required String saleId,
+  });
+
+  /// Adds a payment to an existing sale.
+  Future<void> addPayment({
+    required String organizationId,
+    required String saleId,
+    required PaymentEntity payment,
   });
 }

--- a/lib/features/sales/presentation/controllers/sale_detail_controller.dart
+++ b/lib/features/sales/presentation/controllers/sale_detail_controller.dart
@@ -1,0 +1,161 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../settings/domain/entities/management_entities.dart';
+import '../../../treasury/data/models/treasury_transaction_model.dart';
+import '../../data/models/payment_model.dart';
+import '../../domain/entities/payment_entity.dart';
+import '../../domain/entities/sale_entity.dart';
+import '../models/payment_view_model.dart';
+
+class SaleDetailController {
+  final FirebaseFirestore _firestore;
+
+  SaleDetailController(this._firestore);
+
+  Future<void> addPayment({
+    required String organizationId,
+    required SaleEntity sale,
+    required PaymentViewModel payment,
+  }) async {
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser == null) throw Exception('Utilisateur non connecté');
+
+    await _firestore.runTransaction((transaction) async {
+      // --- 1. LECTURES ---
+      // On lit les méthodes de paiement pour mettre à jour les soldes.
+      final Map<String, DocumentSnapshot> methodSnapshots = {};
+
+      if (!methodSnapshots.containsKey(payment.methodIn.id)) {
+        final ref = _firestore
+            .collection('organisations')
+            .doc(organizationId)
+            .collection('paymentMethods')
+            .doc(payment.methodIn.id);
+        methodSnapshots[payment.methodIn.id] = await transaction.get(ref);
+      }
+      if (payment.change > 0 && !methodSnapshots.containsKey(payment.methodOut.id)) {
+        final ref = _firestore
+            .collection('organisations')
+            .doc(organizationId)
+            .collection('paymentMethods')
+            .doc(payment.methodOut.id);
+        methodSnapshots[payment.methodOut.id] = await transaction.get(ref);
+      }
+
+      // --- 2. ÉCRITURES ---
+      final saleRef = _firestore
+          .collection('organisations')
+          .doc(organizationId)
+          .collection('sales')
+          .doc(sale.id);
+
+      // 2a. Ajout du paiement dans la sous-collection
+      final paymentEntity = PaymentEntity(
+        id: const Uuid().v4(),
+        amount: payment.amountPaid,
+        date: DateTime.now(),
+        paymentMethod: payment.methodIn,
+      );
+      final paymentModel = PaymentModel.fromEntity(paymentEntity);
+      final paymentRef = saleRef.collection('payments').doc(paymentModel.id);
+      transaction.set(paymentRef, paymentModel.toJson());
+
+      // 2b. Mise à jour du document de vente principal
+      final newTotalPaid = sale.totalPaid + payment.amountPaid;
+      final newBalance = sale.grandTotal - newTotalPaid;
+      final newStatus =
+          newBalance <= 0.01 ? PaymentStatus.paid : PaymentStatus.partial;
+
+      transaction.update(saleRef, {
+        'total_paid': newTotalPaid,
+        'payment_status': newStatus.name,
+      });
+
+      // 2c. Mise à jour de la trésorerie et des soldes
+      _updateTreasuryAndBalances(
+        transaction: transaction,
+        organizationId: organizationId,
+        saleId: sale.id,
+        payment: payment,
+        methodSnapshots: methodSnapshots,
+        currentUser: currentUser,
+      );
+    });
+  }
+
+  void _updateTreasuryAndBalances({
+    required FirebaseTransaction transaction,
+    required String organizationId,
+    required String saleId,
+    required PaymentViewModel payment,
+    required Map<String, DocumentSnapshot> methodSnapshots,
+    required User currentUser,
+  }) {
+    if (payment.isSimplePayment) {
+      // Cas simple: 1 transaction, 1 mise à jour de solde
+      final ref = methodSnapshots[payment.methodIn.id]!.reference;
+      transaction.update(ref, {'balance': FieldValue.increment(payment.amountPaid)});
+
+      final treasuryRef = _firestore
+          .collection('organisations')
+          .doc(organizationId)
+          .collection('treasury_transactions')
+          .doc();
+      final tx = TreasuryTransactionModel(
+        id: treasuryRef.id,
+        date: DateTime.now(),
+        amount: payment.amountPaid,
+        paymentMethodId: payment.methodIn.id,
+        paymentMethodName: payment.methodIn.name,
+        type: 'sale_receipt',
+        relatedDocumentId: saleId,
+        userId: currentUser.uid,
+      );
+      transaction.set(treasuryRef, tx.toJson());
+    } else {
+      // Cas complexe: 2 transactions, 2 mises à jour de solde (encaissement + rendu monnaie)
+      // Entrée d'argent
+      final refIn = methodSnapshots[payment.methodIn.id]!.reference;
+      transaction.update(refIn, {'balance': FieldValue.increment(payment.amountGiven)});
+      final treasuryRefIn = _firestore
+          .collection('organisations')
+          .doc(organizationId)
+          .collection('treasury_transactions')
+          .doc();
+      final txIn = TreasuryTransactionModel(
+        id: treasuryRefIn.id,
+        date: DateTime.now(),
+        amount: payment.amountGiven,
+        paymentMethodId: payment.methodIn.id,
+        paymentMethodName: payment.methodIn.name,
+        type: 'sale_receipt',
+        relatedDocumentId: saleId,
+        userId: currentUser.uid,
+      );
+      transaction.set(treasuryRefIn, txIn.toJson());
+
+      // Sortie d'argent (monnaie)
+      final refOut = methodSnapshots[payment.methodOut.id]!.reference;
+      transaction.update(refOut, {'balance': FieldValue.increment(-payment.change)});
+      final treasuryRefOut = _firestore
+          .collection('organisations')
+          .doc(organizationId)
+          .collection('treasury_transactions')
+          .doc();
+      final txOut = TreasuryTransactionModel(
+        id: treasuryRefOut.id,
+        date: DateTime.now(),
+        amount: -payment.change,
+        paymentMethodId: payment.methodOut.id,
+        paymentMethodName: payment.methodOut.name,
+        type: 'sale_change',
+        relatedDocumentId: saleId,
+        userId: currentUser.uid,
+      );
+      transaction.set(treasuryRefOut, txOut.toJson());
+    }
+  }
+}
+

--- a/lib/features/sales/presentation/providers/sales_providers.dart
+++ b/lib/features/sales/presentation/providers/sales_providers.dart
@@ -15,6 +15,7 @@ import '../../domain/usecases/get_clients.dart';
 import '../../domain/usecases/get_all_sales.dart';
 import '../../domain/usecases/get_sale_details.dart';
 import '../controllers/create_sale_controller.dart';
+import '../controllers/sale_detail_controller.dart';
 
 /// Provider for the sales repository
 final salesRepositoryProvider = Provider<SalesRepositoryImpl>((ref) {
@@ -80,6 +81,11 @@ final saleDetailProvider =
 final createSaleControllerProvider = Provider<CreateSaleController>((ref) {
   final repository = ref.watch(salesRepositoryProvider);
   return CreateSaleController(repository, FirebaseFirestore.instance);
+});
+
+/// Controller used on the sale detail screen
+final saleDetailControllerProvider = Provider<SaleDetailController>((ref) {
+  return SaleDetailController(FirebaseFirestore.instance);
 });
 
 /// Search query for filtering sales by customer name


### PR DESCRIPTION
## Summary
- add SaleDetailController to handle sale payments atomically
- expose SaleDetailController via provider and extend repository contract
- allow collecting payments from sale detail UI

## Testing
- `dart format lib/features/sales/presentation/controllers/sale_detail_controller.dart lib/features/sales/presentation/providers/sales_providers.dart lib/features/sales/domain/repositories/sales_repository.dart lib/features/sales/data/repositories/sales_repository_impl.dart lib/features/sales/presentation/screens/sale_detail_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c566e45fa8832d9541263fc7473f4f